### PR TITLE
Added support of 'apns-push-type' header

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ $builder = new Http20Builder($authenticator);
 $sender = $builder->build();
 ```
 
-> **Attention:** visitors are required for adding the headers to HTTP request (apns-id, apns-collapse-id, etc...).
+> **Attention:** visitors are required for adding the headers to HTTP request (apns-id, apns-collapse-id, apns-push-type, etc...).
 
 We support the JSON Web Token authentication, and if you want use JWT, please create `JwtAuthenticator`:
 
@@ -122,7 +122,7 @@ In many issues you must create the notification with custom sound or custom budg
 
 The root of notification slit to next objects:
 
-* Notification - the root object of notification. Store payload, priority, expiration, apns-id, collapse-id.
+* Notification - the root object of notification. Store payload, priority, expiration, apns-id, collapse-id, apns-push-type.
 * Payload - the payload of notification. Store aps data and custom data.
 * Aps - the aps of notification. Store alert, badge, sound, category, thread, content-available.
 * Alert - the alert of notification. Store title, body, launch image and localized data.
@@ -140,6 +140,7 @@ use Apple\ApnPush\Model\Expiration;
 use Apple\ApnPush\Model\Priority;
 use Apple\ApnPush\Model\ApnId;
 use Apple\ApnPush\Model\CollapseId;
+use Apple\ApnPush\Model\PushType;
 
 $alert = (new Alert())
     ->withBody('Hello ;)')
@@ -160,7 +161,8 @@ $notification = (new Notification($payload))
     ->withExpiration(new Expiration(new \DateTime('+1 day')))
     ->withPriority(Priority::immediately())
     ->withApnId(new ApnId('550e8400-e29b-41d4-a716-446655440000'))
-    ->withCollapseId(new CollapseId('some-foo-bar'));
+    ->withCollapseId(new CollapseId('some-foo-bar'))
+    ->withPushType(PushType::alert());
 
 $sender->send($receiver, $notification);
 ```

--- a/src/Model/Notification.php
+++ b/src/Model/Notification.php
@@ -44,21 +44,24 @@ class Notification
     private $collapseId;
 
     /**
-     * Constructor.
-     *
-     * @param Payload         $payload
-     * @param ApnId|null      $apnId
-     * @param Priority|null   $priority
-     * @param Expiration|null $expiration
-     * @param CollapseId|null $collapseId
+     * @var PushType
      */
-    public function __construct(Payload $payload, ApnId $apnId = null, Priority $priority = null, Expiration $expiration = null, CollapseId $collapseId = null)
-    {
+    private $pushType;
+    
+    public function __construct(
+        Payload $payload,
+        ?ApnId $apnId = null,
+        ?Priority $priority = null,
+        ?Expiration $expiration = null,
+        ?CollapseId $collapseId = null,
+        ?PushType $pushType = null
+    ) {
         $this->payload = $payload;
         $this->priority = $priority;
         $this->apnId = $apnId;
         $this->expiration = $expiration;
         $this->collapseId = $collapseId;
+        $this->pushType = $pushType;
     }
 
     /**
@@ -201,5 +204,19 @@ class Notification
     public function getCollapseId(): ?CollapseId
     {
         return $this->collapseId;
+    }
+    
+    public function withPushType(PushType $pushType): Notification
+    {
+        $cloned = clone $this;
+    
+        $cloned->pushType = $pushType;
+    
+        return $cloned;
+    }
+    
+    public function getPushType(): ?PushType
+    {
+        return $this->pushType;
     }
 }

--- a/src/Model/PushType.php
+++ b/src/Model/PushType.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Apple\ApnPush\Model;
+
+/**
+ * The type of the notification
+ * @see https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns
+ */
+final class PushType
+{
+    const TYPE_ALERT      = 'alert';
+    const TYPE_BACKGROUND = 'background';
+    
+    private $value;
+
+    public static function alert(): PushType
+    {
+        return new self(self::TYPE_ALERT);
+    }
+
+    public static function background(): PushType
+    {
+        return new self(self::TYPE_BACKGROUND);
+    }
+    
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+    
+    /**
+     * @param string $type
+     * @throws \InvalidArgumentException
+     */
+    private function __construct(string $type)
+    {
+        if (!in_array($type, [self::TYPE_ALERT, self::TYPE_BACKGROUND], true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Invalid priority "%d". Can be "%s" or "%s".',
+                    $type,
+                    self::TYPE_BACKGROUND,
+                    self::TYPE_ALERT
+                )
+            );
+        }
+        
+        $this->value = $type;
+    }
+}

--- a/src/Protocol/Http/Visitor/AddPushTypeHeaderVisitor.php
+++ b/src/Protocol/Http/Visitor/AddPushTypeHeaderVisitor.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Apple\ApnPush\Protocol\Http\Visitor;
+
+use Apple\ApnPush\Model\Notification;
+use Apple\ApnPush\Protocol\Http\Request;
+
+/**
+ * Visitor for add apns-push-type header to request
+ */
+class AddPushTypeHeaderVisitor implements HttpProtocolVisitorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function visit(Notification $notification, Request $request): Request
+    {
+        $pushType = $notification->getPushType();
+
+        if ($pushType) {
+            $request = $request->withHeader('apns-push-type', (string)$pushType);
+        }
+
+        return $request;
+    }
+}

--- a/src/Sender/Builder/Http20Builder.php
+++ b/src/Sender/Builder/Http20Builder.php
@@ -26,6 +26,7 @@ use Apple\ApnPush\Protocol\Http\Visitor\AddApnIdHeaderVisitor;
 use Apple\ApnPush\Protocol\Http\Visitor\AddCollapseIdHeaderVisitor;
 use Apple\ApnPush\Protocol\Http\Visitor\AddExpirationHeaderVisitor;
 use Apple\ApnPush\Protocol\Http\Visitor\AddPriorityHeaderVisitor;
+use Apple\ApnPush\Protocol\Http\Visitor\AddPushTypeHeaderVisitor;
 use Apple\ApnPush\Protocol\Http\Visitor\HttpProtocolChainVisitor;
 use Apple\ApnPush\Protocol\Http\Visitor\HttpProtocolVisitorInterface;
 use Apple\ApnPush\Protocol\HttpProtocol;
@@ -140,6 +141,7 @@ class Http20Builder implements BuilderInterface
         $this->addVisitor(new AddPriorityHeaderVisitor());
         $this->addVisitor(new AddApnIdHeaderVisitor());
         $this->addVisitor(new AddCollapseIdHeaderVisitor());
+        $this->addVisitor(new AddPushTypeHeaderVisitor());
 
         return $this;
     }

--- a/tests/Model/NotificationTest.php
+++ b/tests/Model/NotificationTest.php
@@ -19,6 +19,7 @@ use Apple\ApnPush\Model\Expiration;
 use Apple\ApnPush\Model\Notification;
 use Apple\ApnPush\Model\Payload;
 use Apple\ApnPush\Model\Priority;
+use Apple\ApnPush\Model\PushType;
 use PHPUnit\Framework\TestCase;
 
 class NotificationTest extends TestCase
@@ -106,6 +107,18 @@ class NotificationTest extends TestCase
 
         self::assertEquals(new CollapseId('some'), $notificationWithChangedCollapseId->getCollapseId());
         self::assertNotEquals(spl_object_hash($notification), spl_object_hash($notificationWithChangedCollapseId));
+    }
+    
+    /**
+     * @test
+     */
+    public function shouldSuccessChangePushType()
+    {
+        $notification = new Notification($this->createPayload());
+        $notificationWithChangedPushType = $notification->withPushType(PushType::alert());
+        
+        self::assertEquals(PushType::alert(), $notificationWithChangedPushType->getPushType());
+        self::assertNotEquals(spl_object_hash($notification), spl_object_hash($notificationWithChangedPushType));
     }
 
     /**

--- a/tests/Model/PushTypeTest.php
+++ b/tests/Model/PushTypeTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Apple\ApnPush\Model;
+
+use Apple\ApnPush\Model\PushType;
+use PHPUnit\Framework\TestCase;
+
+class PushTypeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldSuccessCreate()
+    {
+        self::assertEquals(PushType::TYPE_ALERT, (string)PushType::alert());
+        self::assertEquals(PushType::TYPE_BACKGROUND, (string)PushType::background());
+    }
+}

--- a/tests/Protocol/Http/Visitor/AddPushTypeHeaderVisitorTest.php
+++ b/tests/Protocol/Http/Visitor/AddPushTypeHeaderVisitorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Apple\ApnPush\Protocol\Http\Visitor;
+
+use Apple\ApnPush\Model\Alert;
+use Apple\ApnPush\Model\Aps;
+use Apple\ApnPush\Model\Notification;
+use Apple\ApnPush\Model\Payload;
+use Apple\ApnPush\Model\PushType;
+use Apple\ApnPush\Protocol\Http\Request;
+use Apple\ApnPush\Protocol\Http\Visitor\AddPushTypeHeaderVisitor;
+use PHPUnit\Framework\TestCase;
+
+class AddPushTypeHeaderVisitorTest extends TestCase
+{
+    /**
+     * @var AddPushTypeHeaderVisitor
+     */
+    private $visitor;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->visitor = new AddPushTypeHeaderVisitor();
+    }
+
+    /**
+     * @test
+     */
+    public function shouldAddHeaderForPushType()
+    {
+        $payload = new Payload(new Aps(new Alert()));
+        $notification = new Notification($payload, null, null, null, null, PushType::alert());
+        $request = new Request('https://domain.com', '{}');
+
+        $visitedRequest = $this->visitor->visit($notification, $request);
+
+        $headers = $visitedRequest->getHeaders();
+
+        self::assertEquals([
+            'apns-push-type' => PushType::TYPE_ALERT,
+        ], $headers);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotAddHeaderForPriority()
+    {
+        $payload = new Payload(new Aps(new Alert()));
+        $notification = new Notification($payload);
+        $request = new Request('https://domain.com', '{}');
+
+        $visitedRequest = $this->visitor->visit($notification, $request);
+
+        $headers = $visitedRequest->getHeaders();
+        self::assertEquals([], $headers);
+    }
+}

--- a/tests/Sender/Builder/Http20BuilderTest.php
+++ b/tests/Sender/Builder/Http20BuilderTest.php
@@ -20,6 +20,7 @@ use Apple\ApnPush\Protocol\Http\Visitor\AddApnIdHeaderVisitor;
 use Apple\ApnPush\Protocol\Http\Visitor\AddCollapseIdHeaderVisitor;
 use Apple\ApnPush\Protocol\Http\Visitor\AddExpirationHeaderVisitor;
 use Apple\ApnPush\Protocol\Http\Visitor\AddPriorityHeaderVisitor;
+use Apple\ApnPush\Protocol\Http\Visitor\AddPushTypeHeaderVisitor;
 use Apple\ApnPush\Protocol\Http\Visitor\HttpProtocolChainVisitor;
 use Apple\ApnPush\Protocol\Http\Visitor\HttpProtocolVisitorInterface;
 use Apple\ApnPush\Protocol\HttpProtocol;
@@ -77,12 +78,14 @@ class Http20BuilderTest extends TestCase
         $uriFactory = $this->createMock(UriFactoryInterface::class);
         $visitor = $this->createMock(HttpProtocolVisitorInterface::class);
 
+        $priority = 0;
         $chainVisitor = new HttpProtocolChainVisitor();
-        $chainVisitor->add(new AddExpirationHeaderVisitor(), 1);
-        $chainVisitor->add(new AddPriorityHeaderVisitor(), 2);
-        $chainVisitor->add(new AddApnIdHeaderVisitor(), 3);
-        $chainVisitor->add(new AddCollapseIdHeaderVisitor(), 4);
-        $chainVisitor->add($visitor, 5);
+        $chainVisitor->add(new AddExpirationHeaderVisitor(), ++$priority);
+        $chainVisitor->add(new AddPriorityHeaderVisitor(), ++$priority);
+        $chainVisitor->add(new AddApnIdHeaderVisitor(), ++$priority);
+        $chainVisitor->add(new AddCollapseIdHeaderVisitor(), ++$priority);
+        $chainVisitor->add(new AddPushTypeHeaderVisitor(), ++$priority);
+        $chainVisitor->add($visitor, ++$priority);
 
         $builder
             ->setAuthenticator($authenticator)


### PR DESCRIPTION
Apple introduced a new header 'apns-push-type' which is required for devices running iOS 13 and later, or watchOS 6 and later.

> (Required when delivering notifications to devices running iOS 13 and later, or watchOS 6 and later. Ignored on earlier system versions.) The type of the notification. The value of this header is alert or background. Specify alert when the delivery of your notification displays an alert, plays a sound, or badges your app's icon. Specify background for silent notifications that do not interact with the user.

Please, see [Sending Notification Requests to APNs](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns]) for more details.